### PR TITLE
+ details to members, subunit and group

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 /venv
 .idea
+loona/__pycache__/member.cpython-36.pyc
+loona/__init__.pyc
+loona/__pycache__/__init__.cpython-36.pyc
+loona/member.pyc
+loona/__pycache__/group.cpython-36.pyc
+loona/__pycache__/subunit.cpython-36.pyc

--- a/loona/__init__.py
+++ b/loona/__init__.py
@@ -1,4 +1,6 @@
 import loona.member
+import loona.subunit
+import loona.group
 
 heejin = loona.member.Heejin()
 hyunjin = loona.member.Hyunjin()
@@ -16,6 +18,15 @@ olivia = loona.member.Olivia()
 
 def get_members():
     return [heejin, hyunjin, haseul, yeojin, vivi, kimlip, jinsoul, choerry, yves, chuu, gowon, olivia]
+
+OneThird = loona.subunit.OneThird()
+OddEyeCircle = loona.subunit.OddEyeCircle()
+yyxy = loona.subunit.yyxy()
+
+def get_subunits():
+    return ['LOONA 1/3, LOONA ODD EYE CIRCLE, LOONA yyxy']
+
+group = loona.group.LOONA()
 
 
 if __name__ == "__main__":

--- a/loona/group.py
+++ b/loona/group.py
@@ -1,0 +1,37 @@
+import datetime
+
+
+class Group:
+
+    def __init__(self, name, **kwargs):
+        self.name = name
+        self.name_kr = kwargs.get('name_kr')
+        self.name_zh = kwargs.get('name_zh')
+        self.name_ja = kwargs.get('name_ja')
+        self.debut = kwargs.get('debut')
+        self.leaders = kwargs.get('leaders')
+        self.members = kwargs.get('members')
+        self.releases = kwargs.get('releases')
+        self.concerts = kwargs.get('concerts')
+
+    def __call__(self):
+        return """Loona (stylized as LOOΠΔ) is a South Korean girl group formed by Blockberry Creative.
+                Its twelve members were revealed in a periodic fashion, corresponding to their Korean 
+                name Idarui Sonyeo (이달의 소녀), which translates to "Girl of the Month"."""
+    
+    def DaysSinceDebut(self):
+        return(datetime.date.today() - self.debut).days
+
+class LOONA(Group):
+    
+    def __init__(self):
+        Group.__init__(self, "LOONA",
+                        name_kr="이달의 소녀",
+                        name_zh='本月少女',
+                        name_ja='今月の少女',
+                        debut=datetime.date(2018, 8, 20),
+                        leaders='Haseul, Kim Lip, Yves',
+                        members='Heejin, Hyunjin, Haseul, Yeojin, ViVi, Kim Lip, Jinsoul, Choerry, Yves, Chuu, Go Won, Olivia Hye',
+                        releases='favOriTe (2018), [+ +] (2018), Orbit 1.0 (2018), [x x] (2019)',
+                        concerts='LOONAbirth (2018), LOONAVERSE (2019)'
+                        )

--- a/loona/member.py
+++ b/loona/member.py
@@ -1,4 +1,5 @@
 import datetime
+import math
 
 
 class Member:
@@ -18,12 +19,16 @@ class Member:
         self.song_url = kwargs.get('song_url')
         self.subunit = kwargs.get('subunit')
         self.location = kwargs.get('location')
+        self.debut = kwargs.get('debut')
 
     def stream(self):
         print(self.song_url)
 
     def age(self):
-        return (datetime.date.today() - self.birthday).days/365.2425
+        return math.floor((datetime.date.today() - self.birthday).days/365.2425)
+
+    def DaysSinceDebut(self):
+        return (datetime.date.today() - self.debut).days
 
 
 class Heejin(Member):
@@ -41,7 +46,8 @@ class Heejin(Member):
                         song="ViViD",
                         song_url="https://www.youtube.com/watch?v=-FCYE87P5L0",
                         subunit="1/3",
-                        location="Paris, France"
+                        location="Paris, France",
+                        debut=datetime.date(2016, 9, 25)
                         )
 
 
@@ -60,7 +66,8 @@ class Hyunjin(Member):
                         song="Around You",
                         song_url="https://www.youtube.com/watch?v=mybsDDymrsc",
                         subunit="1/3",
-                        location="Tokyo, Japan"
+                        location="Tokyo, Japan",
+                        debut=datetime.date(2016, 10, 28)
                         )
 
 
@@ -79,7 +86,8 @@ class Haseul(Member):
                         song="Let Me In",
                         song_url="https://www.youtube.com/watch?v=6a4BWpBJppI",
                         subunit="1/3",
-                        location="Iceland & London, England"
+                        location="Iceland & London, England",
+                        debut=datetime.date(2016, 12, 8)
                         )
 
 
@@ -97,7 +105,8 @@ class Yeojin(Member):
                         animal="Frog",
                         song="Kiss Later",
                         song_url="https://www.youtube.com/watch?v=thpTOAS1Vgg",
-                        location="Taipei, Taiwan"
+                        location="Taipei, Taiwan",
+                        debut=datetime.date(2017, 1, 4)
                         )
 
 
@@ -116,7 +125,8 @@ class Vivi(Member):
                         song="Everyday I Love You",
                         song_url="https://www.youtube.com/watch?v=ZNcBZM5SvbY",
                         subunit="1/3",
-                        location="Busan, South Korea"
+                        location="Busan, South Korea",
+                        debut=datetime.date(2017, 2, 13)
                         )
         self.birthname_ch = "黃珈熙"
 
@@ -136,6 +146,7 @@ class KimLip(Member):
                         song="Eclipse",
                         song_url="https://www.youtube.com/watch?v=_qJEoSa3Ie0",
                         subunit="Odd Eye Circle",
+                        debut=datetime.date(2017, 5, 15)
                         )
 
 
@@ -153,7 +164,8 @@ class Jinsoul(Member):
                         animal="Blue Betta",
                         song="Singing in the Rain",
                         song_url="https://www.youtube.com/watch?v=RWeyOyY_puQ",
-                        subunit="Odd Eye Circle"
+                        subunit="Odd Eye Circle",
+                        debut=datetime.date(2017, 6, 13)
                         )
 
 
@@ -172,7 +184,8 @@ class Choerry(Member):
                         fruit="Cherry",
                         song="Love Cherry Motion",
                         song_url="https://www.youtube.com/watch?v=VBbeuXW8Nko",
-                        subunit="Odd Eye Circle"
+                        subunit="Odd Eye Circle",
+                        debut=datetime.date(2017, 7, 12)
                         )
 
 
@@ -191,7 +204,8 @@ class Yves(Member):
                         fruit="Apple",
                         song="new",
                         song_url="https://www.youtube.com/watch?v=LIDe-yTxda0",
-                        subunit="YYXY"
+                        subunit="YYXY",
+                        debut=datetime.date(2017, 11, 14)
                         )
 
 
@@ -210,7 +224,8 @@ class Chuu(Member):
                         fruit="Strawberry",
                         song="Heart Attack",
                         song_url="https://www.youtube.com/watch?v=BVVfMFS3mgc",
-                        subunit="YYXY"
+                        subunit="YYXY",
+                        debut=datetime.date(2017, 12, 14)
                         )
 
 
@@ -229,7 +244,8 @@ class Gowon(Member):
                         fruit="Pineapple",
                         song="One&Only",
                         song_url="https://www.youtube.com/watch?v=m5qwcYL8a0o",
-                        subunit="YYXY"
+                        subunit="YYXY",
+                        debut=datetime.date(2018, 1, 15)
                         )
 
 
@@ -248,7 +264,8 @@ class Olivia(Member):
                         fruit="Blood Plum",
                         song="Egoist",
                         song_url="https://www.youtube.com/watch?v=UkY8HvgvBJ8",
-                        subunit="YYXY"
+                        subunit="YYXY",
+                        debut=datetime.date(2018, 3, 17)
                         )
 
     def roll(self):

--- a/loona/subunit.py
+++ b/loona/subunit.py
@@ -1,0 +1,50 @@
+import datetime
+
+
+class SubUnit:
+
+    def __init__(self, name, **kwargs):
+        self.name = name
+        self.name_kr = kwargs.get('name_kr')
+        self.debut = kwargs.get('debut')
+        self.leader = kwargs.get('leader')
+        self.members = kwargs.get('members')
+        self.releases = kwargs.get('releases')
+
+    def DaysSinceDebut(self):
+        return(datetime.date.today() - self.debut).days
+
+class OneThird(SubUnit):
+    
+    def __init__(self):
+        SubUnit.__init__(self, "LOONA 1/3",
+                        name_kr="이달의 소녀 1/3",
+                        debut=datetime.date(2017, 3, 12),
+                        leader='Haseul',
+                        members='Heejin, Hyunjin, Haseul, ViVi',
+                        releases='Love & Live (2017), Love & Evil (2017)'
+                        )
+
+
+class OddEyeCircle(SubUnit):
+
+    def __init__(self):
+        SubUnit.__init__(self, "LOONA ODD EYE CIRCLE",
+                        name_kr="이달의 소녀 오드아이써클",
+                        debut=datetime.date(2017, 9, 21),
+                        leader='Kim Lip',
+                        members='Kim Lip, Jinsoul, Choerry',
+                        releases='Mix & Match (2017), Loonatic (English Version) (2017), Max & Match (2017)'
+                        )
+
+
+class yyxy(SubUnit):
+
+    def __init__(self):
+        SubUnit.__init__(self, "LOONA yyxy",
+                        name_kr="이달의 소녀 yyxy",
+                        debut=datetime.date(2018, 5, 30),
+                        leader='Yves',
+                        members='Yves, Chuu, Go Won, Olivia Hye',
+                        releases='Beauty & The Beat (2018)'
+                        )     


### PR DESCRIPTION
Added:
- Number of days since debut under members, since we Orbits like to track the no. of days (Heejin is approaching 1000 days soon!)
- Subunit information (1/3, Odd Eye Circle, yyxy)
- Group information (LOONA as a group)

Changed:
- For age of members, I added a math.floor function because whole numbers are nicer.

I wanted to add the track list inside releases as well, but the multiline string didn't parse well in Python. Any ideas how to do so?