### PR TITLE
Added new locations to members and subunits, modified location of docstring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ loona/__pycache__/__init__.cpython-36.pyc
 loona/member.pyc
 loona/__pycache__/group.cpython-36.pyc
 loona/__pycache__/subunit.cpython-36.pyc
+.vscode/settings.json

--- a/loona/__init__.py
+++ b/loona/__init__.py
@@ -1,3 +1,9 @@
+"""Loona (stylized as LOOΠΔ) is a South Korean girl group
+formed by Blockberry Creative. Its twelve members were
+revealed in a periodic fashion, corresponding to their
+Korean name Idarui Sonyeo (이달의 소녀), which translates
+to "Girl of the Month"."""
+
 import loona.member
 import loona.subunit
 

--- a/loona/member.py
+++ b/loona/member.py
@@ -133,7 +133,7 @@ class Vivi(Member):
                         location="Busan, South Korea",
                         debut=datetime.date(2017, 2, 13)
                         )
-        self.birthname_ch = "黃珈熙"
+        self.birthname_zh = "黃珈熙"
 
 
 class KimLip(Member):
@@ -151,6 +151,7 @@ class KimLip(Member):
                         song="Eclipse",
                         song_url="https://www.youtube.com/watch?v=_qJEoSa3Ie0",
                         subunit="Odd Eye Circle",
+                        location='Gimcheon, South Korea',
                         debut=datetime.date(2017, 5, 15)
                         )
 
@@ -190,6 +191,7 @@ class Choerry(Member):
                         song="Love Cherry Motion",
                         song_url="https://www.youtube.com/watch?v=VBbeuXW8Nko",
                         subunit="Odd Eye Circle",
+                        location='Jeju Island, South Korea',
                         debut=datetime.date(2017, 7, 12)
                         )
 
@@ -210,6 +212,7 @@ class Yves(Member):
                         song="new",
                         song_url="https://www.youtube.com/watch?v=LIDe-yTxda0",
                         subunit="YYXY",
+                        location='Seoul, South Korea',
                         debut=datetime.date(2017, 11, 14)
                         )
 
@@ -270,6 +273,7 @@ class Olivia(Member):
                         song="Egoist",
                         song_url="https://www.youtube.com/watch?v=UkY8HvgvBJ8",
                         subunit="YYXY",
+                        location='Bucheon, South Korea',
                         debut=datetime.date(2018, 3, 17)
                         )
 

--- a/loona/subunit.py
+++ b/loona/subunit.py
@@ -74,11 +74,3 @@ class LOONA(SubUnit):
                          )
         self.name_zh = '本月少女',
         self.name_ja = '今月の少女',
-
-    def __repr__(self):
-        return """Loona (stylized as LOOΠΔ) is a South Korean girl group
-                  formed by Blockberry Creative. Its twelve members were
-                  revealed in a periodic fashion, corresponding to their Korean
-                  name Idarui Sonyeo (이달의 소녀), which translates to "Girl of
-                  the Month".""".replace(
-                  "\n", "").replace("                  ", " ")

--- a/loona/subunit.py
+++ b/loona/subunit.py
@@ -12,7 +12,7 @@ class SubUnit:
         self.members = kwargs.get('members', [])
         self.releases = kwargs.get('releases', [])
         self.concerts = kwargs.get('concerts', [])
-        self.locations = kwargs.get('locations', [])
+        self.location = kwargs.get('location', [])
 
     def __str__(self):
         return self.name

--- a/loona/subunit.py
+++ b/loona/subunit.py
@@ -12,6 +12,7 @@ class SubUnit:
         self.members = kwargs.get('members', [])
         self.releases = kwargs.get('releases', [])
         self.concerts = kwargs.get('concerts', [])
+        self.locations = kwargs.get('locations', [])
 
     def __str__(self):
         return self.name
@@ -27,11 +28,12 @@ class SubUnit:
 
 
 class OneThird(SubUnit):
-    
+
     def __init__(self):
         SubUnit.__init__(self, "LOONA 1/3",
                          name_kr="이달의 소녀 1/3",
                          debut=datetime.date(2017, 3, 12),
+                         location=['New Zealand', 'Hong Kong'],
                          releases=['Love & Live (2017)', 'Love & Evil (2017)']
                          )
 
@@ -42,7 +44,10 @@ class OddEyeCircle(SubUnit):
         SubUnit.__init__(self, "LOONA ODD EYE CIRCLE",
                          name_kr="이달의 소녀 오드아이써클",
                          debut=datetime.date(2017, 9, 21),
-                         releases=['Mix & Match (2017)', 'Loonatic (English Version) (2017)', 'Max & Match (2017)']
+                         location=['Los Angeles, California'],
+                         releases=['Mix & Match (2017)',
+                                   'Loonatic (English Version) (2017)',
+                                   'Max & Match (2017)']
                          )
 
 
@@ -52,6 +57,7 @@ class YYXY(SubUnit):
         SubUnit.__init__(self, "LOONA yyxy",
                          name_kr="이달의 소녀 yyxy",
                          debut=datetime.date(2018, 5, 30),
+                         location=['Szabadkígyós, Hungary'],
                          releases=['Beauty & The Beat (2018)']
                          )
 
@@ -62,13 +68,17 @@ class LOONA(SubUnit):
         SubUnit.__init__(self, "LOONA",
                          name_kr="이달의 소녀",
                          debut=datetime.date(2018, 8, 20),
-                         releases=['favOriTe (2018)', '[+ +] (2018)', 'Orbit 1.0 (2018)', '[x x] (2019)'],
+                         releases=['favOriTe (2018)', '[+ +] (2018)',
+                                   'Orbit 1.0 (2018)', '[x x] (2019)'],
                          concerts=['LOONAbirth (2018)', 'LOONAVERSE (2019)']
                          )
         self.name_zh = '本月少女',
         self.name_ja = '今月の少女',
 
-    def __call__(self):
-        return """Loona (stylized as LOOΠΔ) is a South Korean girl group formed by Blockberry Creative.
-                Its twelve members were revealed in a periodic fashion, corresponding to their Korean 
-                name Idarui Sonyeo (이달의 소녀), which translates to "Girl of the Month"."""
+    def __repr__(self):
+        return """Loona (stylized as LOOΠΔ) is a South Korean girl group
+                  formed by Blockberry Creative. Its twelve members were
+                  revealed in a periodic fashion, corresponding to their Korean
+                  name Idarui Sonyeo (이달의 소녀), which translates to "Girl of
+                  the Month".""".replace(
+                  "\n", "").replace("                  ", " ")


### PR DESCRIPTION
Added:
- New locations to members and subunits if it was known 
(Jinsoul, Chuu and Go Won's MV locations are still unknown as of now)

Changed:
- Language codes to align to ISO 639-1
- Multi-line code to avoid E501 of PEP8 (Line too long)
- Docstring on LOONA is shifted over to `__init__.py`
  - Running `help(loona)` after importing returns:

```
Help on package loona:

NAME
    loona

DESCRIPTION
    Loona (stylized as LOOΠΔ) is a South Korean girl group
    formed by Blockberry Creative. Its twelve members were
    revealed in a periodic fashion, corresponding to their
    Korean name Idarui Sonyeo (이달의 소녀), which translates
    to "Girl of the Month".
```