### PR TITLE
Fixed __repr__ for get_members(), get_subunits() and get_albums()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ loona/member.pyc
 loona/__pycache__/group.cpython-36.pyc
 loona/__pycache__/subunit.cpython-36.pyc
 .vscode/settings.json
+loona/__pycache__/release.cpython-36.pyc

--- a/loona/__init__.py
+++ b/loona/__init__.py
@@ -70,7 +70,8 @@ multiplemultiple = loona.release.MultipleMultiple()
 
 
 def get_albums():
-    return [plusplus, multiplemultiple]
+    releases = [plusplus, multiplemultiple]
+    return releases
 
 
 if __name__ == "__main__":

--- a/loona/__init__.py
+++ b/loona/__init__.py
@@ -71,7 +71,8 @@ multiplemultiple = loona.release.MultipleMultiple()
 
 def get_albums():
     releases = [plusplus, multiplemultiple]
-    return releases
+    for release in releases:
+        print(release)
 
 
 if __name__ == "__main__":

--- a/loona/member.py
+++ b/loona/member.py
@@ -20,7 +20,7 @@ class Member:
         self.location = kwargs.get('location')
         self.debut = kwargs.get('debut')
 
-    def __str__(self):
+    def __repr__(self):
         return self.name
 
     def stream(self):

--- a/loona/release.py
+++ b/loona/release.py
@@ -9,7 +9,7 @@ class Song:
         self.lyrics = kwargs.get('lyrics')
         self.url = kwargs.get('url')
 
-    def __str__(self):
+    def __repr__(self):
         return self.name
 
 
@@ -20,8 +20,8 @@ class Album:
         self.release_date = kwargs.get('release_date')
         self.songs = kwargs.get('songs', [])
 
-    def __str__(self):
-        return self.name + "\n" + self.tracklist()
+    def __repr__(self):
+        return self.name + "\n" + self.tracklist() + "\n"
 
     def tracklist(self):
         return "\n".join(f"{i}. {song} - {song.duration}" for i, song in enumerate(self.songs, start=1))

--- a/loona/subunit.py
+++ b/loona/subunit.py
@@ -14,7 +14,7 @@ class SubUnit:
         self.concerts = kwargs.get('concerts', [])
         self.location = kwargs.get('location', [])
 
-    def __str__(self):
+    def __repr__(self):
         return self.name
 
     def add_member(self, member: Member):


### PR DESCRIPTION
Changed:
- `__str__` attributes of Member, Song, Album and Subunit classes to `__repr__`
- `get_albums()` to print each LOONA release
  - The 3 methods defined in `__init__.py` now print properly